### PR TITLE
fix: remove node globals

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -1,6 +1,6 @@
 const { Buffer } = require('buffer')
 const BufferList = require('bl/BufferList')
-const { S_IFMT, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK } = require('fs-constants')
+const { S_IFMT, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK } = require('iso-constants')
 const concat = require('it-concat')
 const Headers = require('./pack-headers')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -773,11 +773,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1017,6 +1012,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "iso-constants": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
     },
     "it-concat": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bl": "^4.0.0",
     "buffer": "^5.4.3",
-    "fs-constants": "^1.0.0",
+    "iso-constants": "^0.1.2",
     "it-concat": "^1.0.0",
     "it-reader": "^2.0.0",
     "p-defer": "^3.0.0"


### PR DESCRIPTION
fs-contants relies on node constants global to exist and be injected by browser bundlers (which is super outdated).

iso-constants removes the need for the bundler to inject outdated packages and also auto updates the constants to the node version been used.

related to https://github.com/ipfs/js-ipfs/issues/2924