### PR TITLE
fix: esbuild warning about ?? operator in lte-reader

### DIFF
--- a/src/lte-reader.ts
+++ b/src/lte-reader.ts
@@ -23,7 +23,7 @@ export function lteReader (source: Source<Uint8Array>): LteReader {
           overflow = overflow.sublist(bytes)
         } else if (overflow.length < bytes) {
           const { value: nextValue, done } = await input.next(bytes - overflow.length)
-          if (done === true ?? nextValue == null) {
+          if (done === true) {
             throw Object.assign(
               new Error(`stream ended before ${bytes - overflow.length} bytes became available`),
               { code: 'ERR_UNDER_READ' }

--- a/test/lte-reader.spec.ts
+++ b/test/lte-reader.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'aegir/chai'
+import { lteReader } from '../src/lte-reader.js'
+
+describe('lte-reader', () => {
+  it('should read', async () => {
+    const reader = lteReader([
+      Uint8Array.from([0, 1, 2, 3, 4]),
+      Uint8Array.from([5, 6, 7, 8, 9])
+    ])
+
+    const { value } = await reader.next(6)
+
+    if (value == null) {
+      throw new Error('No value received')
+    }
+
+    expect(value.subarray()).to.equalBytes(Uint8Array.from([0, 1, 2, 3, 4, 5]))
+  })
+
+  it('should reject on under-read', async () => {
+    const reader = lteReader([
+      Uint8Array.from([0, 1, 2, 3, 4]),
+      Uint8Array.from([5, 6, 7, 8, 9])
+    ])
+
+    await expect(reader.next(100)).to.eventually.be.rejected
+      .with.property('code', 'ERR_UNDER_READ')
+  })
+})


### PR DESCRIPTION
Restores the [pre-typescript](https://github.com/alanshaw/it-tar/blob/f6e492a44070816c4989af89e1602e656a27ecd4/lte-reader.js#L20) behaviour of `lte-reader` to just checking that the `done` value is true.

Adds tests to prevent regressions.

Closes #67